### PR TITLE
Fixing notification body

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ You can push a notification from Terminal using `cURL`:
 ```
 curl --include \
      --request POST \
-     --data-binary 'Buy cheese and bread for breakfast.' \
+     --data-binary 'msg=Buy cheese and bread for breakfast.' \
      https://api2.scaledrone.com/dIVCxD01G4x1sDtC/notifications/publish
 ```

--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ if (!Notification) {
             });
             room.on('data', function (data) {
                 // Create a new notification from incoming data
-                var notification = new Notification(data);
+                var notification = new Notification(data.msg);
                 // Hide it after 4 seconds
                 setTimeout(function () {
                     notification.close();


### PR DESCRIPTION
Change-Id: I8648d4799476bc0092707ce86de914e4ce0e8952

Added a key `msg` to the data payload in order to successfully show the body in the notification.

Tested on Mac OS 10.10.5 with Chrome 47.0.2526 and Firefox 43.0.3
